### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/app/api/[...page]/route.ts
+++ b/app/api/[...page]/route.ts
@@ -5,7 +5,7 @@ import * as cheerio from "cheerio";
 export const dynamic = "force-dynamic";
 
 export async function GET(
-    request: NextRequest,
+    _request: NextRequest,
     { params }: { params: Promise<{ page?: string[] }> }
 ) {
     try {
@@ -20,7 +20,7 @@ export async function GET(
             return new NextResponse("Invalid path segment", { status: 400 });
         }
 
-        const configuredBaseUrl = process.env.NEXT_PUBLIC_SITE_URL;
+        const configuredBaseUrl = process.env["NEXT_PUBLIC_SITE_URL"];
         if (!configuredBaseUrl) {
             return new NextResponse("Server misconfiguration: missing base URL", { status: 500 });
         }
@@ -44,6 +44,7 @@ export async function GET(
                 "User-Agent": "Mozilla/5.0 (compatible; TreblleBot/1.0)",
             },
             cache: "no-store",
+            signal: AbortSignal.timeout(8000),
         });
 
         if (!response.ok) {
@@ -110,9 +111,6 @@ export async function GET(
         });
     } catch (error) {
         console.error("Markdown conversion error:", error);
-        return new NextResponse(
-            `Error converting to markdown: ${error instanceof Error ? error.message : "Unknown error"}`,
-            { status: 500 }
-        );
+        return new NextResponse("Internal server error", { status: 500 });
     }
 }

--- a/app/api/[...page]/route.ts
+++ b/app/api/[...page]/route.ts
@@ -20,26 +20,23 @@ export async function GET(
             return new NextResponse("Invalid path segment", { status: 400 });
         }
 
-        const originUrl = request.nextUrl;
-
-        // Restrict protocol and disallow typical internal/loopback SSRF targets
-        if (originUrl.protocol !== "http:" && originUrl.protocol !== "https:") {
-            return new NextResponse("Invalid origin protocol", { status: 400 });
+        const configuredBaseUrl = process.env.NEXT_PUBLIC_SITE_URL;
+        if (!configuredBaseUrl) {
+            return new NextResponse("Server misconfiguration: missing base URL", { status: 500 });
         }
 
-        const hostname = originUrl.hostname.toLowerCase();
-        const disallowedHosts = new Set<string>([
-            "localhost",
-            "127.0.0.1",
-            "::1",
-        ]);
-        const isIpLiteral = /^[0-9.]+$/.test(hostname) || hostname.includes(":");
-        if (disallowedHosts.has(hostname) || isIpLiteral) {
-            return new NextResponse("Disallowed origin host", { status: 400 });
+        let trustedBaseUrl: URL;
+        try {
+            trustedBaseUrl = new URL(configuredBaseUrl);
+        } catch {
+            return new NextResponse("Server misconfiguration: invalid base URL", { status: 500 });
         }
 
-        const baseUrl = originUrl.origin;
-        const targetUrl = `${baseUrl}${originalPath}`;
+        if (trustedBaseUrl.protocol !== "http:" && trustedBaseUrl.protocol !== "https:") {
+            return new NextResponse("Server misconfiguration: invalid base URL protocol", { status: 500 });
+        }
+
+        const targetUrl = new URL(originalPath, trustedBaseUrl).toString();
 
         const response = await fetch(targetUrl, {
             headers: {


### PR DESCRIPTION
Potential fix for [https://github.com/Treblle/treblle-documentation/security/code-scanning/1](https://github.com/Treblle/treblle-documentation/security/code-scanning/1)

General fix: ensure outbound requests are built from a server-controlled base URL (or strict allowlist), and only append a validated path segment from user input. Do not use `request.nextUrl.origin` (or other request-controlled host/protocol components) directly.

Best fix in this file: replace the dynamic `originUrl.origin` usage with a trusted base URL read from configuration (e.g., `process.env.NEXT_PUBLIC_SITE_URL`), validate that configured URL is `http/https`, normalize it, and construct `targetUrl` via `new URL(originalPath, trustedBaseUrl)`. Keep existing path validation. This preserves behavior (fetching same-site path content) while removing attacker influence over host/protocol.

Changes needed in `app/api/[...page]/route.ts`:
- Remove the `originUrl`/hostname/disallowed host logic tied to request URL.
- Add trusted base URL parsing/validation from environment.
- Build `targetUrl` using `new URL(...).toString()` from trusted base + validated path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
